### PR TITLE
2023 12 maintenance

### DIFF
--- a/aws-batch-using-nice-dcv.dockerfile
+++ b/aws-batch-using-nice-dcv.dockerfile
@@ -48,13 +48,15 @@ RUN wget -q http://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.8
 RUN rpm --import https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY \
  && mkdir -p /tmp/dcv-inst \
  && cd /tmp/dcv-inst \
- && wget -qO- https://d1uj6qtbmh3dt5.cloudfront.net/2020.0/Servers/nice-dcv-2020.0-8428-el7.tgz |tar xfz - --strip-components=1 \
+ && wget -qO- https://d1uj6qtbmh3dt5.cloudfront.net/2023.1/Servers/nice-dcv-2023.1-16388-el7-x86_64.tgz |tar xfz - --strip-components=1 \
  && yum -y install \
-    nice-dcv-gl-2020.0.759-1.el7.i686.rpm \
-    nice-dcv-gltest-2020.0.229-1.el7.x86_64.rpm \
-    nice-dcv-gl-2020.0.759-1.el7.x86_64.rpm \
-    nice-dcv-server-2020.0.8428-1.el7.x86_64.rpm \
-    nice-xdcv-2020.0.296-1.el7.x86_64.rpm
+    nice-dcv-server-2023.1.16388-1.el7.x86_64.rpm \
+    nice-dcv-simple-external-authenticator-2023.1.228-1.el7.x86_64.rpm \
+    nice-dcv-web-viewer-2023.1.16388-1.el7.x86_64.rpm \
+    nice-xdcv-2023.1.565-1.el7.x86_64.rpm \
+    nice-dcv-gl-2023.1.1047-1.el7.x86_64.rpm \
+    nice-dcv-gltest-2023.1.325-1.el7.x86_64.rpm \
+ && rm -rf /tmp/dcv-inst
 
 # Define the dcvserver.service
 COPY dcvserver.service /usr/lib/systemd/system/dcvserver.service

--- a/aws-batch-using-nice-dcv.dockerfile
+++ b/aws-batch-using-nice-dcv.dockerfile
@@ -30,7 +30,7 @@ RUN yum -y install glx-utils mesa-dri-drivers xorg-x11-server-Xorg \
                    gnu-free-mono-fonts gnu-free-sans-fonts \
                    gnu-free-serif-fonts desktop-backgrounds-gnome
 
-# Install Nvidia Driver, configure Xorg, install NICE DCV server
+# Install Nvidia Driver
 RUN wget -q http://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run -O /tmp/NVIDIA-installer.run \
  && bash /tmp/NVIDIA-installer.run --accept-license \
                               --no-runlevel-check \
@@ -43,8 +43,9 @@ RUN wget -q http://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.8
                               --no-nvidia-modprobe \
                               --no-kernel-module-source \
  && rm -f /tmp/NVIDIA-installer.run \
- && nvidia-xconfig --preserve-busid \
- && rpm --import https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY \
+ && nvidia-xconfig --preserve-busid
+# Configure Xorg, install NICE DCV server
+RUN rpm --import https://d1uj6qtbmh3dt5.cloudfront.net/NICE-GPG-KEY \
  && mkdir -p /tmp/dcv-inst \
  && cd /tmp/dcv-inst \
  && wget -qO- https://d1uj6qtbmh3dt5.cloudfront.net/2020.0/Servers/nice-dcv-2020.0-8428-el7.tgz |tar xfz - --strip-components=1 \

--- a/aws-batch-using-nice-dcv.dockerfile
+++ b/aws-batch-using-nice-dcv.dockerfile
@@ -31,7 +31,7 @@ RUN yum -y install glx-utils mesa-dri-drivers xorg-x11-server-Xorg \
                    gnu-free-serif-fonts desktop-backgrounds-gnome
 
 # Install Nvidia Driver
-RUN wget -q http://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run -O /tmp/NVIDIA-installer.run \
+RUN wget -q https://us.download.nvidia.com/tesla/535.129.03/NVIDIA-Linux-x86_64-535.129.03.run -O /tmp/NVIDIA-installer.run \
  && bash /tmp/NVIDIA-installer.run --accept-license \
                               --no-runlevel-check \
                               --no-questions \

--- a/aws-batch-using-nice-dcv.dockerfile
+++ b/aws-batch-using-nice-dcv.dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest as dcv
+FROM amazonlinux:2 as dcv
 
 # Prepare the container to run systemd inside
 ENV container docker


### PR DESCRIPTION
*Issue #, if available:*
- fix https://github.com/aws-samples/aws-batch-using-nice-dcv/issues/6
- fix https://github.com/aws-samples/aws-batch-using-nice-dcv/issues/7
- fix https://github.com/aws-samples/aws-batch-using-nice-dcv/issues/8


*Description of changes:*

- use latest available dcv version 
- version lock to al2 to avoid breaking changes with al2023 (like lack of built-in gnome support)
- use latest nvidia drivers (same ones used by EKS optimized GPU AL2 AMI)


*Test state*

I have only built the image so far, so have not tested this from within an AWS batch or other EC2 context.  The container image builds successfully in about 90 seconds on my machine.

I tried to launch it on an EL9 based environment, but this does not work even with `--privileged`, seemingly because of incompatibilities with EL9 and EL7's cgroups. When I switched to rocky9 as a base in https://github.com/cazlo/aws-batch-using-nice-dcv/pull/1, I was able to get past this issue, which gives me some confidence this will work without much fuss in an AWS context.

*Disclaimer*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
